### PR TITLE
Use pytest-remotedata for offline/online test split

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,8 @@ omit =
   sunpy_soar/*setup_package*
   sunpy_soar/extern/*
   sunpy_soar/version*
+  sunpy_soar/_dev/*
+  */sunpy_soar/_dev/*
   */sunpy_soar/conftest.py
   */sunpy_soar/*setup_package*
   */sunpy_soar/extern/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,11 @@ jobs:
       toxdeps: tox-pypi-filter
       posargs: -n auto
       envs: |
-        - linux: py314
-        - windows: py312
-        - macos: py312
-        - linux: py312-oldestdeps
-        - linux: py314-devdeps
+        - linux: py314-online
+        - windows: py312-online
+        - macos: py312-online
+        - linux: py312-oldestdeps-online
+        - linux: py314-devdeps-online
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/docs/dev_guide/query.rst
+++ b/docs/dev_guide/query.rst
@@ -31,15 +31,13 @@ Using the example below,
     <sunpy.net.fido_factory.UnifiedResponse object at ...>
     Results from 1 Provider:
     <BLANKLINE>
-    680 Results from the SOARClient:
+    ... Results from the SOARClient:
     <BLANKLINE>
-    Instrument     Data product    Level        Start time               End time        Filesize SOOP Name
+    Instrument     Data product    Level        Start time               End time        Filesize SOOP Name Sensor
                                                                                           Mbyte
-    ---------- ------------------- ----- ----------------------- ----------------------- -------- ---------
-           RPW rpw-tds-surv-hist2d    L2 2022-10-09 00:00:00.000 2022-10-10 00:00:00.000    0.084      none
+    ---------- ------------------- ----- ----------------------- ----------------------- -------- --------- ------
+           RPW rpw-tds-surv-hist2d    L2 2022-10-09 00:00:00.000 2022-10-10 00:00:00.000    0.084      none    TDS
     ...
-    <BLANKLINE>
-    <BLANKLINE>
 
 Here the query's "REQUEST" type to "doQueryFilteredByDistance", which is a special method that filters the entire database based on the specified distance value.
 

--- a/docs/how_to/wavelength.rst
+++ b/docs/how_to/wavelength.rst
@@ -30,21 +30,14 @@ When a single wavelength is provided it is interpreted as the wavelength.
     <sunpy.net.fido_factory.UnifiedResponse object at ...>
     Results from 1 Provider:
     <BLANKLINE>
-    8 Results from the SOARClient:
+    ... Results from the SOARClient:
     <BLANKLINE>
     Instrument  Data product  Level        Start time               End time        Filesize SOOP Name Detector Wavelength
                                                                                      Mbyte
     ---------- -------------- ----- ----------------------- ----------------------- -------- --------- -------- ----------
          METIS metis-uv-image    L2 2023-02-01 01:00:48.690 2023-02-01 01:11:46.866     0.85      none      UVD      121.6
-         METIS metis-uv-image    L2 2023-02-01 01:30:48.680 2023-02-01 01:41:45.540     0.85      none      UVD      121.6
-         METIS metis-uv-image    L2 2023-02-01 02:00:48.671 2023-02-01 02:11:44.213    12.64      none      UVD      121.6
-         METIS metis-uv-image    L2 2023-02-01 02:30:48.661 2023-02-01 02:41:42.887    12.64      none      UVD      121.6
-         METIS metis-uv-image    L2 2023-02-01 03:00:48.652 2023-02-01 03:11:41.560    12.64      none      UVD      121.6
-         METIS metis-uv-image    L2 2023-02-01 03:30:48.643 2023-02-01 03:41:40.233    12.64      none      UVD      121.6
-         METIS metis-uv-image    L2 2023-02-01 04:00:48.633 2023-02-01 04:11:38.907    12.64      none      UVD      121.6
-         METIS metis-uv-image    L2 2023-02-01 04:30:38.163 2023-02-01 04:40:37.625    12.64      none      UVD      121.6
-    <BLANKLINE>
-    <BLANKLINE>
+    ...
+
 
 For instruments EUI, METIS and SOLOHI passing a range of Wavelength
 ===================================================================
@@ -59,32 +52,10 @@ When a range of wavelength is provided, it is interpreted as the wavemin and wav
     <sunpy.net.fido_factory.UnifiedResponse object at ...>
     Results from 1 Provider:
     <BLANKLINE>
-    64 Results from the SOARClient:
+    ... Results from the SOARClient:
     <BLANKLINE>
     Instrument    Data product    Level        Start time               End time        Filesize SOOP Name Detector Wavelength
                                                                                          Mbyte
     ---------- ------------------ ----- ----------------------- ----------------------- -------- --------- -------- ----------
          METIS        metis-vl-tb    L2 2023-02-01 01:00:00.147 2023-02-01 01:24:37.923    12.64      none      VLD      610.0
-         METIS    metis-vl-stokes    L2 2023-02-01 01:00:00.147 2023-02-01 01:24:37.923   21.067      none      VLD      610.0
-         METIS        metis-vl-pb    L2 2023-02-01 01:00:00.147 2023-02-01 01:24:37.923    12.64      none      VLD      610.0
-         METIS     metis-vl-image    L2 2023-02-01 01:00:00.147 2023-02-01 01:23:05.525   12.643      none      VLD      610.0
-         METIS metis-vl-pol-angle    L2 2023-02-01 01:00:00.147 2023-02-01 01:24:37.923    12.64      none      VLD      610.0
-         METIS     metis-vl-image    L2 2023-02-01 01:00:30.944 2023-02-01 01:23:36.322   12.643      none      VLD      610.0
-         METIS     metis-vl-image    L2 2023-02-01 01:01:01.741 2023-02-01 01:24:07.127   12.643      none      VLD      610.0
-         METIS     metis-vl-image    L2 2023-02-01 01:01:32.538 2023-02-01 01:24:37.922   12.643      none      VLD      610.0
-         METIS    metis-vl-stokes    L2 2023-02-01 01:30:00.150 2023-02-01 01:54:37.922   21.067      none      VLD      610.0
-         METIS metis-vl-pol-angle    L2 2023-02-01 01:30:00.150 2023-02-01 01:54:37.922    12.64      none      VLD      610.0
-           ...                ...   ...                     ...                     ...      ...       ...      ...        ...
-         METIS     metis-vl-image    L2 2023-02-01 04:01:01.774 2023-02-01 04:24:07.158   50.388      none      VLD      610.0
-         METIS     metis-vl-image    L2 2023-02-01 04:01:32.571 2023-02-01 04:24:37.955   50.388      none      VLD      610.0
-         METIS metis-vl-pol-angle    L2 2023-02-01 04:30:00.201 2023-02-01 04:54:37.981   50.388      none      VLD      610.0
-         METIS    metis-vl-stokes    L2 2023-02-01 04:30:00.201 2023-02-01 04:54:37.981   83.981      none      VLD      610.0
-         METIS        metis-vl-tb    L2 2023-02-01 04:30:00.201 2023-02-01 04:54:37.981   50.388      none      VLD      610.0
-         METIS        metis-vl-pb    L2 2023-02-01 04:30:00.201 2023-02-01 04:54:37.981   50.388      none      VLD      610.0
-         METIS     metis-vl-image    L2 2023-02-01 04:30:00.201 2023-02-01 04:53:05.585   50.388      none      VLD      610.0
-         METIS     metis-vl-image    L2 2023-02-01 04:30:30.999 2023-02-01 04:53:36.383   50.388      none      VLD      610.0
-         METIS     metis-vl-image    L2 2023-02-01 04:31:01.796 2023-02-01 04:54:07.184   50.388      none      VLD      610.0
-         METIS     metis-vl-image    L2 2023-02-01 04:31:32.593 2023-02-01 04:54:37.979   50.388      none      VLD      610.0
-    Length = 64 rows
-    <BLANKLINE>
-    <BLANKLINE>
+    ...

--- a/examples/searching_with_sensor.py
+++ b/examples/searching_with_sensor.py
@@ -1,10 +1,10 @@
 """
-=============================================================
-Searching for EPD/EPT data with the `a.soar.Sensor` attribute
-=============================================================
+===============================================================
+Searching for EPD/EPT data with the ``a.soar.Sensor`` attribute
+===============================================================
 
 This example demonstrates how to search and download Solar Orbiter data for a specific instrument sensor.
-Here, we will build a query for EPD data, specifically from the EPT sensor using ``a.soar.Sensor``.
+Here, we will build a query for EPD data, specifically from the EPT sensor using `a.soar.Sensor <sunpy_soar.attrs.Sensor>`.
 """
 
 import sunpy.net.attrs as a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ tests-only = [
   "pytest-cov",
   "pytest-doctestplus",
   "pytest",
+  "pytest-remotedata",
 ]
 tests = [
   "sunpy_soar[tests-deps,tests-only]",

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,6 +22,9 @@ addopts =
     --doctest-rst
     -p no:unraisableexception
     -p no:threadexception
+markers =
+    remote_data: marks this test function as needing remote data.
+remote_data_strict = true
 filterwarnings =
     # Turn all warnings into errors so they do not pass silently.
     error

--- a/sunpy_soar/tests/test_attrs.py
+++ b/sunpy_soar/tests/test_attrs.py
@@ -1,0 +1,204 @@
+import astropy.units as u
+import pytest
+import sunpy.net.attrs as a
+from sunpy.util.exceptions import SunpyUserWarning
+
+from sunpy_soar._attrs import SOOP, Distance, Product, Sensor, walker
+
+
+def _apply(attr):
+    """Apply a single attr via the walker and return the resulting params list."""
+    params = []
+    walker.apply(attr, params)
+    return params
+
+
+def test_time():
+    attr = a.Time("2023-01-15 06:30:00", "2023-01-16 12:45:00")
+    params = _apply(attr)
+    assert len(params) == 1
+    assert params[0] == "begin_time>='2023-01-15 06:30:00' AND begin_time<='2023-01-16 12:45:00'"
+
+
+def test_level_from_int():
+    """Integer level should be converted to 'L<n>' string."""
+    params = _apply(a.Level(2))
+    assert params == ["level='L2'"]
+
+
+def test_level_from_string():
+    """String levels should be uppercased."""
+    params = _apply(a.Level("l1"))
+    assert params == ["level='L1'"]
+
+
+def test_level_low_latency():
+    """Low-latency level strings should pass through uppercased."""
+    params = _apply(a.Level("LL02"))
+    assert params == ["level='LL02'"]
+
+
+def test_level_invalid_warns():
+    """An unrecognised level should emit a SunpyUserWarning."""
+    with pytest.warns(SunpyUserWarning, match="level not in list of allowed levels"):
+        _apply(a.Level("L9"))
+
+
+def test_instrument():
+    params = _apply(a.Instrument("EUI"))
+    assert params == ["instrument='EUI'"]
+
+
+def test_product():
+    params = _apply(Product("eui-fsi174-image"))
+    assert params == ["descriptor='eui-fsi174-image'"]
+
+
+def test_provider():
+    params = _apply(a.Provider("SOAR"))
+    assert params == ["provider='SOAR'"]
+
+
+def test_soop():
+    params = _apply(SOOP("r_small_mres_mcad_ar_long_term"))
+    assert params == ["soop_name='r_small_mres_mcad_ar_long_term'"]
+
+
+def test_detector():
+    params = _apply(a.Detector("HRI_EUV"))
+    assert params == ["Detector='HRI_EUV'"]
+
+
+def test_sensor():
+    params = _apply(Sensor("ept"))
+    assert params == ["Sensor='ept'"]
+
+
+def test_wavelength():
+    params = _apply(a.Wavelength(304 * u.AA, 304 * u.AA))
+    assert len(params) == 1
+    assert params[0] == "Wavemin='304.0' AND Wavemax='304.0'"
+
+
+def test_wavelength_range():
+    params = _apply(a.Wavelength(171 * u.AA, 304 * u.AA))
+    assert params[0] == "Wavemin='171.0' AND Wavemax='304.0'"
+
+
+def test_distance():
+    params = _apply(Distance(0.3 * u.AU, 0.5 * u.AU))
+    assert len(params) == 1
+    assert params[0] == "DISTANCE(0.3,0.5)"
+
+
+def test_distance_out_of_bounds_warns():
+    """Distance values outside 0.28-1.0 AU should emit a warning."""
+    with pytest.warns(SunpyUserWarning, match="Distance values must be within the range"):
+        _apply(Distance(0.1 * u.AU, 0.5 * u.AU))
+
+
+def test_distance_max_out_of_bounds_warns():
+    """Only the max being out of bounds should also warn."""
+    with pytest.warns(SunpyUserWarning, match="Distance values must be within the range"):
+        _apply(Distance(0.3 * u.AU, 1.5 * u.AU))
+
+
+def test_and_applier():
+    """AttrAnd applier should recurse and collect all sub-attr params."""
+    compound = a.Instrument("EUI") & a.Level(1) & Product("eui-fsi174-image")
+    params = _apply(compound)
+    assert "instrument='EUI'" in params
+    assert "level='L1'" in params
+    assert "descriptor='eui-fsi174-image'" in params
+    assert len(params) == 3
+
+
+def test_create_from_single_attr():
+    """A single DataAttr should produce a list containing one sub-list."""
+    result = walker.create(a.Instrument("EUI"))
+    assert len(result) == 1
+    assert result == [["instrument='EUI'"]]
+
+
+def test_create_from_and():
+    """An AND of attrs should produce a single sub-list with all params."""
+    query = a.Instrument("EUI") & a.Level(2)
+    result = walker.create(query)
+    assert len(result) == 1
+    assert "instrument='EUI'" in result[0]
+    assert "level='L2'" in result[0]
+
+
+def test_create_from_or():
+    """An OR should produce multiple sub-lists, one per branch."""
+    query = a.Instrument("EUI") | a.Instrument("STIX")
+    result = walker.create(query)
+    assert len(result) == 2
+    assert result[0] == [["instrument='EUI'"]]
+    assert result[1] == [["instrument='STIX'"]]
+
+
+def test_create_from_compound_or_and():
+    """OR of two AND branches should produce two sub-lists."""
+    query = (a.Instrument("EUI") & a.Level(1)) | (a.Instrument("STIX") & a.Level(2))
+    result = walker.create(query)
+    assert len(result) == 2
+    # Each branch is a list of one sub-list
+    eui_params = result[0][0]
+    stix_params = result[1][0]
+    assert "instrument='EUI'" in eui_params
+    assert "level='L1'" in eui_params
+    assert "instrument='STIX'" in stix_params
+    assert "level='L2'" in stix_params
+
+
+def test_lowercase():
+    """Product value should always be lowercased."""
+    p = Product("EUI-FSI174-IMAGE")
+    assert p.value == "eui-fsi174-image"
+
+
+def test_already_lowercase():
+    p = Product("eui-fsi174-image")
+    assert p.value == "eui-fsi174-image"
+
+
+def test_mixed_case():
+    p = Product("Eui-Fsi174-Image")
+    assert p.value == "eui-fsi174-image"
+
+
+def test_converts_km_to_au():
+    """Distance should convert km inputs to AU."""
+    d = Distance(0.5 * u.AU.to(u.km) * u.km, 0.6 * u.AU.to(u.km) * u.km)
+    assert u.isclose(d.min, 0.5 * u.AU)
+    assert u.isclose(d.max, 0.6 * u.AU)
+
+
+def test_au_passthrough():
+    """AU inputs should be stored directly."""
+    d = Distance(0.3 * u.AU, 0.4 * u.AU)
+    assert u.isclose(d.min, 0.3 * u.AU)
+    assert u.isclose(d.max, 0.4 * u.AU)
+
+
+def test_non_scalar_raises():
+    """Non-scalar quantities should raise ValueError."""
+    with pytest.raises(ValueError, match="scalar"):
+        Distance([0.3, 0.4] * u.AU, 0.5 * u.AU)
+
+
+def test_non_scalar_max_raises():
+    with pytest.raises(ValueError, match="scalar"):
+        Distance(0.3 * u.AU, [0.4, 0.5] * u.AU)
+
+
+def test_collides_with_same_class():
+    d1 = Distance(0.3 * u.AU, 0.4 * u.AU)
+    d2 = Distance(0.5 * u.AU, 0.6 * u.AU)
+    assert d1.collides(d2) is True
+
+
+def test_does_not_collide_with_other_type():
+    d = Distance(0.3 * u.AU, 0.4 * u.AU)
+    assert d.collides(a.Time("2023-01-01", "2023-01-02")) is False

--- a/sunpy_soar/tests/test_sunpy_soar.py
+++ b/sunpy_soar/tests/test_sunpy_soar.py
@@ -7,6 +7,7 @@ import sunpy.map
 from requests.exceptions import HTTPError
 from sunpy.net import Fido
 from sunpy.net import attrs as a
+from sunpy.net.base_client import QueryResponseTable
 from sunpy.util.exceptions import SunpyUserWarning
 
 from sunpy_soar.client import SOARClient
@@ -112,6 +113,7 @@ def test_registered_instr_attrs() -> None:
     instr_attr = a.Instrument
     assert "SOAR" in instr_attr._attr_registry[instr_attr].client
     assert "stix" in instr_attr._attr_registry[instr_attr].name
+
 
 def test_registered_sensor_attrs() -> None:
     # Check if SolO sensors are registered in a.soar.Sensor
@@ -468,7 +470,7 @@ def test_distance_out_of_bounds_warning_post71(recwarn):
     # Run the search and ensure it raises an HTTPError
     query = Fido.search(distance & instrument & product & level & time)
     # Check if the warning was raised
-    assert query['soar'].errors
+    assert query["soar"].errors
     # Check if the warning was raised
     warnings_list = recwarn.list
     assert any(
@@ -520,10 +522,11 @@ def test_soar_server_down_post71() -> None:
     level = a.Level("LL02")
     product = a.soar.Product("mag")
 
-    query =  Fido.search(time, level, product)
-    assert isinstance(query['soar'].errors, RuntimeError)
-    assert ("The SOAR server returned an invalid JSON response. It may be down or not functioning correctly."
-            == str(query['soar'].errors))
+    query = Fido.search(time, level, product)
+    assert isinstance(query["soar"].errors, RuntimeError)
+    assert "The SOAR server returned an invalid JSON response. It may be down or not functioning correctly." == str(
+        query["soar"].errors
+    )
 
 
 def test_can_handle_with_time_and_instrument():
@@ -538,36 +541,134 @@ def test_can_handle_with_distance_no_time():
 
 def test_can_handle_with_distance_and_time():
     """Distance + Time together should be handleable."""
-    assert SOARClient._can_handle_query(
-        a.soar.Distance(0.3 * u.AU, 0.5 * u.AU),
-        a.Time("2023-01-01", "2023-01-02"),
-    ) is True
+    assert (
+        SOARClient._can_handle_query(
+            a.soar.Distance(0.3 * u.AU, 0.5 * u.AU),
+            a.Time("2023-01-01", "2023-01-02"),
+        )
+        is True
+    )
 
 
 def test_can_handle_wrong_provider():
     """A non-SOAR provider should be rejected."""
-    assert SOARClient._can_handle_query(
-        a.Time("2023-01-01", "2023-01-02"),
-        a.Provider("SDAC"),
-    ) is False
+    assert (
+        SOARClient._can_handle_query(
+            a.Time("2023-01-01", "2023-01-02"),
+            a.Provider("SDAC"),
+        )
+        is False
+    )
 
 
 def test_can_handle_unknown_instrument():
     """An instrument not in the SOAR registry should be rejected."""
-    assert SOARClient._can_handle_query(
-        a.Time("2023-01-01", "2023-01-02"),
-        a.Instrument("AIA"),
-    ) is False
+    assert (
+        SOARClient._can_handle_query(
+            a.Time("2023-01-01", "2023-01-02"),
+            a.Instrument("AIA"),
+        )
+        is False
+    )
 
 
 def test_can_handle_unsupported_attr():
     """An attr type not in the required/optional sets should be rejected."""
-    assert SOARClient._can_handle_query(
-        a.Time("2023-01-01", "2023-01-02"),
-        a.Physobs("intensity"),
-    ) is False
+    assert (
+        SOARClient._can_handle_query(
+            a.Time("2023-01-01", "2023-01-02"),
+            a.Physobs("intensity"),
+        )
+        is False
+    )
 
 
 def test_can_handle_time_only():
     """Time with no instrument should be handleable (the no-instrument search path)."""
     assert SOARClient._can_handle_query(a.Time("2023-01-01", "2023-01-02")) is True
+
+
+def _make_query_results(rows):
+    """Build a minimal QueryResponseTable from a list of row dicts for testing fetch."""
+    return QueryResponseTable(
+        {
+            "Instrument": [r["Instrument"] for r in rows],
+            "Data product": [r["Data product"] for r in rows],
+            "Level": [r["Level"] for r in rows],
+            "Start time": [r["Start time"] for r in rows],
+            "End time": [r["End time"] for r in rows],
+            "Data item ID": [r["Data item ID"] for r in rows],
+            "Filename": [r["Filename"] for r in rows],
+            "Filesize": [r["Filesize"] for r in rows],
+            "SOOP Name": [r["SOOP Name"] for r in rows],
+        },
+        client=SOARClient(),
+    )
+
+
+def test_fetch_science_url(tmp_path):
+    """Science-level rows should produce URLs with product_type=SCIENCE."""
+    qrt = _make_query_results(
+        [
+            {
+                "Instrument": "EUI",
+                "Data product": "eui-fsi174-image",
+                "Level": "L1",
+                "Start time": "2021-02-01",
+                "End time": "2021-02-02",
+                "Data item ID": "solo_L1_eui-fsi174-image_20210201",
+                "Filename": "solo_L1_eui-fsi174-image_20210201.fits",
+                "Filesize": 1000000,
+                "SOOP Name": "none",
+            },
+        ]
+    )
+
+    queued = []
+
+    class FakeDownloader:
+        def enqueue_file(self, url, filename):
+            queued.append((url, filename))
+
+    SOARClient().fetch(qrt, path=str(tmp_path / "{file}"), downloader=FakeDownloader())
+
+    assert len(queued) == 1
+    url, filepath = queued[0]
+    assert "product_type=SCIENCE" in url
+    assert "product_type=LOW_LATENCY" not in url
+    assert "data_item_id=solo_L1_eui-fsi174-image_20210201" in url
+    assert filepath.endswith("solo_L1_eui-fsi174-image_20210201.fits")
+
+
+def test_fetch_low_latency_url(tmp_path):
+    """Low-latency rows should produce URLs with product_type=LOW_LATENCY."""
+    qrt = _make_query_results(
+        [
+            {
+                "Instrument": "EPD",
+                "Data product": "epd-het-asun-rates",
+                "Level": "LL02",
+                "Start time": "2020-11-13",
+                "End time": "2020-11-14",
+                "Data item ID": "solo_LL02_epd-het-asun-rates_20201113",
+                "Filename": "solo_LL02_epd-het-asun-rates_20201113.fits",
+                "Filesize": 500000,
+                "SOOP Name": "none",
+            },
+        ]
+    )
+
+    queued = []
+
+    class FakeDownloader:
+        def enqueue_file(self, url, filename):
+            queued.append((url, filename))
+
+    SOARClient().fetch(qrt, path=str(tmp_path / "{file}"), downloader=FakeDownloader())
+
+    assert len(queued) == 1
+    url, filepath = queued[0]
+    assert "product_type=LOW_LATENCY" in url
+    assert "product_type=SCIENCE" not in url
+    assert "data_item_id=solo_LL02_epd-het-asun-rates_20201113" in url
+    assert filepath.endswith("solo_LL02_epd-het-asun-rates_20201113.fits")

--- a/sunpy_soar/tests/test_sunpy_soar.py
+++ b/sunpy_soar/tests/test_sunpy_soar.py
@@ -672,3 +672,79 @@ def test_fetch_low_latency_url(tmp_path):
     assert "product_type=SCIENCE" not in url
     assert "data_item_id=solo_LL02_epd-het-asun-rates_20201113" in url
     assert filepath.endswith("solo_LL02_epd-het-asun-rates_20201113.fits")
+
+
+def test_add_join_single_wavelength():
+    """When wavemin == wavemax, the parameter should be rewritten to Wavelength='value'."""
+    query = [
+        "instrument='EUI'",
+        "begin_time>='2023-01-01 00:00:00' AND begin_time<='2023-01-02 00:00:00'",
+        "Wavemin='304.0' AND Wavemax='304.0'",
+    ]
+    where, _, _ = SOARClient.add_join_to_query(query, "v_sc_data_item", "v_eui_sc_fits")
+    # Single wavelength should become Wavelength='304.0' with h2. prefix
+    assert "h2.Wavelength='304.0'" in where
+    assert "Wavemin" not in where
+    assert "Wavemax" not in where
+
+
+def test_add_join_wavelength_range():
+    """When wavemin != wavemax, Wavemin and h2.Wavemax should be used."""
+    query = [
+        "instrument='EUI'",
+        "begin_time>='2023-01-01 00:00:00' AND begin_time<='2023-01-02 00:00:00'",
+        "Wavemin='171.0' AND Wavemax='304.0'",
+    ]
+    where, _, _ = SOARClient.add_join_to_query(query, "v_sc_data_item", "v_eui_sc_fits")
+    # Range should keep Wavemin with h2. prefix and explicitly prefix Wavemax with h2.
+    assert "h2.Wavemin='171.0'" in where
+    assert "h2.Wavemax='304.0'" in where
+
+
+def test_add_join_stix_no_dimension_index():
+    """STIX (stx in table name) should not add dimension_index='1' to the query."""
+    query = [
+        "instrument='STIX'",
+        "begin_time>='2023-01-01 00:00:00' AND begin_time<='2023-01-02 00:00:00'",
+        "level='L1'",
+    ]
+    where, _, _ = SOARClient.add_join_to_query(query, "v_sc_data_item", "v_stx_sc_fits")
+    assert "dimension_index" not in where
+
+
+def test_add_join_non_stix_has_dimension_index():
+    """Non-STIX instruments should include dimension_index='1' in the query."""
+    query = [
+        "instrument='EUI'",
+        "begin_time>='2023-01-01 00:00:00' AND begin_time<='2023-01-02 00:00:00'",
+        "level='L1'",
+    ]
+    where, _, _ = SOARClient.add_join_to_query(query, "v_sc_data_item", "v_eui_sc_fits")
+    assert "h2.dimension_index='1'" in where
+
+
+def test_add_join_detector_prefix():
+    """Detector parameters should get the h2. prefix, not h1."""
+    query = [
+        "instrument='EUI'",
+        "begin_time>='2023-01-01 00:00:00' AND begin_time<='2023-01-02 00:00:00'",
+        "Detector='HRI_EUV'",
+    ]
+    where, _, _ = SOARClient.add_join_to_query(query, "v_sc_data_item", "v_eui_sc_fits")
+    assert "h2.Detector='HRI_EUV'" in where
+    assert "h1.Detector" not in where
+
+
+def test_add_join_no_instrument_table():
+    """When instrument_table is empty, FROM should have no JOIN and SELECT should omit detector/wavelength columns."""
+    query = [
+        "instrument='MAG'",
+        "begin_time>='2023-01-01 00:00:00' AND begin_time<='2023-01-02 00:00:00'",
+        "level='L1'",
+    ]
+    _, from_part, select = SOARClient.add_join_to_query(query, "v_sc_data_item", "")
+    assert "JOIN" not in from_part
+    assert from_part == "v_sc_data_item AS h1"
+    assert "h2.detector" not in select
+    assert "h2.wavelength" not in select
+    assert "h2.dimension_index" not in select

--- a/sunpy_soar/tests/test_sunpy_soar.py
+++ b/sunpy_soar/tests/test_sunpy_soar.py
@@ -13,6 +13,8 @@ from sunpy_soar.client import SOARClient
 
 SUNPY_VERSION = (sunpy.version.major, sunpy.version.minor)
 
+
+@pytest.mark.remote_data
 def test_search() -> None:
     instrument = a.Instrument("EUI")
     time = a.Time("2022-02-11", "2022-02-12")
@@ -39,6 +41,7 @@ def test_search() -> None:
     sunpy.map.Map(fname)
 
 
+@pytest.mark.remote_data
 def test_search_low_latency() -> None:
     time = a.Time("2020-11-13", "2020-11-14")
     level = a.Level("LL02")
@@ -52,6 +55,7 @@ def test_search_low_latency() -> None:
     assert len(files) == 1
 
 
+@pytest.mark.remote_data
 def test_insitu_search() -> None:
     instrument = a.Instrument("MAG")
     time = a.Time("2020-04-16", "2020-04-17")
@@ -65,6 +69,7 @@ def test_insitu_search() -> None:
     assert len(files) == 1
 
 
+@pytest.mark.remote_data
 def test_no_results() -> None:
     instrument = a.Instrument("EUI")
     time = a.Time("2019-02-01", "2019-02-02")
@@ -74,6 +79,7 @@ def test_no_results() -> None:
     assert len(res) == 0
 
 
+@pytest.mark.remote_data
 def test_no_instrument() -> None:
     # Check that a time only search returns results
     time = a.Time("2020-04-16", "2020-04-17")
@@ -81,6 +87,7 @@ def test_no_instrument() -> None:
     assert len(res) == 63
 
 
+@pytest.mark.remote_data
 def test_download_path(tmp_path) -> None:
     # Check that we can download things to a custom path using
     # the search parameters
@@ -119,6 +126,7 @@ def test_registered_soop_names() -> None:
     assert "\nr_small_mres_mcad_ar_long_term" in soop_attr
 
 
+@pytest.mark.remote_data
 def test_search_soop() -> None:
     instrument = a.Instrument("EUI")
     time = a.Time("2022-04-01 01:00", "2022-04-01 02:00")
@@ -132,6 +140,7 @@ def test_search_soop() -> None:
     assert res.file_num == 0
 
 
+@pytest.mark.remote_data
 def test_when_soar_provider_passed() -> None:
     # Tests when a.Provider.soar is passed that only SOARClient results are returned
     instrument = a.Instrument("EUI")
@@ -153,6 +162,7 @@ def test_when_sdac_provider_passed() -> None:
     assert res["vso"]
 
 
+@pytest.mark.remote_data
 def test_when_wrong_provider_passed() -> None:
     # Tests that no results are returned when a provider is passed which does not provide EUI data.
     # This is different from the above test because the SDAC and the SOAR both provide EUI data while
@@ -164,6 +174,7 @@ def test_when_wrong_provider_passed() -> None:
     assert len(res) == 0
 
 
+@pytest.mark.remote_data
 def test_search_wavelength_detector_column() -> None:
     instrument = a.Instrument("EUI")
     time = a.Time("2021-02-01", "2021-02-02")
@@ -174,6 +185,7 @@ def test_search_wavelength_detector_column() -> None:
     assert "Detector" in res[0].columns
 
 
+@pytest.mark.remote_data
 def test_search_detector_instrument_dimension_2() -> None:
     # Instruments "EUI", "METIS", "PHI" and "SOLOHI" have two dimensions in the SOAR data.
     # Selecting no dimension index in the query results in two identical output rows.
@@ -187,6 +199,7 @@ def test_search_detector_instrument_dimension_2() -> None:
     assert res.file_num == 266
 
 
+@pytest.mark.remote_data
 def test_search_detector_instrument_dimension_4() -> None:
     # The "SPICE" instrument has four dimensions in the SOAR data. As a result,
     # selecting no dimension index in the query results in four identical output rows.
@@ -200,6 +213,7 @@ def test_search_detector_instrument_dimension_4() -> None:
     assert res.file_num == 11
 
 
+@pytest.mark.remote_data
 def test_invalid_detector() -> None:
     instrument = a.Instrument("SPICE")
     time = a.Time("2023-03-03 15:00", "2023-03-03 16:00")
@@ -210,6 +224,7 @@ def test_invalid_detector() -> None:
     assert res.file_num == 0
 
 
+@pytest.mark.remote_data
 def test_wavelength_column_wavelength_exists() -> None:
     # For instruments EUI, METIS and SOLOHI "wavelength" column is available.
     # Test to check if the "Wavelength" column exists in the search results.
@@ -222,6 +237,7 @@ def test_wavelength_column_wavelength_exists() -> None:
     assert res.file_num == 12
 
 
+@pytest.mark.remote_data
 def test_wavelength_single() -> None:
     # Test to check if the wavelength value is filtered for a single value provided.
     instrument = a.Instrument("EUI")
@@ -233,6 +249,7 @@ def test_wavelength_single() -> None:
         assert all(table["Wavelength"] == 304)
 
 
+@pytest.mark.remote_data
 def test_wavelength_range() -> None:
     # Test to check if the wavelength value is filtered for wavemin and wavemax provided.
     instrument = a.Instrument("EUI")
@@ -312,6 +329,7 @@ def test_distance_join_query():
     )
 
 
+@pytest.mark.remote_data
 def test_distance_search_remote_sensing():
     instrument = a.Instrument("RPW")
     product = a.soar.Product("rpw-tnr-surv")
@@ -321,6 +339,7 @@ def test_distance_search_remote_sensing():
     assert res.file_num > 40
 
 
+@pytest.mark.remote_data
 def test_distance_search_insitu():
     instrument = a.Instrument("METIS")
     level = a.Level(2)
@@ -330,6 +349,7 @@ def test_distance_search_insitu():
     assert res.file_num == 310
 
 
+@pytest.mark.remote_data
 def test_distance_time_search():
     instrument = a.Instrument("EUI")
     time = a.Time("2023-04-27", "2023-04-28")
@@ -345,6 +365,7 @@ def test_distance_time_search():
 
 # Remove this test and the mark from below once min sunpy dep >=7.1
 @pytest.mark.skipif(SUNPY_VERSION >= (7, 1), reason="Skip post sunpy 7.1")
+@pytest.mark.remote_data
 def test_distance_out_of_bounds_warning(recwarn):
     instrument = a.Instrument("EUI")
     time = a.Time("2023-04-27", "2023-04-28")
@@ -364,6 +385,7 @@ def test_distance_out_of_bounds_warning(recwarn):
 
 
 @pytest.mark.skipif(SUNPY_VERSION < (7, 1), reason="Skip pre sunpy 7.1")
+@pytest.mark.remote_data
 def test_distance_out_of_bounds_warning_post71(recwarn):
     instrument = a.Instrument("EUI")
     time = a.Time("2023-04-27", "2023-04-28")

--- a/sunpy_soar/tests/test_sunpy_soar.py
+++ b/sunpy_soar/tests/test_sunpy_soar.py
@@ -524,3 +524,50 @@ def test_soar_server_down_post71() -> None:
     assert isinstance(query['soar'].errors, RuntimeError)
     assert ("The SOAR server returned an invalid JSON response. It may be down or not functioning correctly."
             == str(query['soar'].errors))
+
+
+def test_can_handle_with_time_and_instrument():
+    """Time + a known SOAR instrument should be handleable."""
+    assert SOARClient._can_handle_query(a.Time("2023-01-01", "2023-01-02"), a.Instrument("EUI")) is True
+
+
+def test_can_handle_with_distance_no_time():
+    """Distance alone (no Time) should be handleable since Distance replaces Time as required."""
+    assert SOARClient._can_handle_query(a.soar.Distance(0.3 * u.AU, 0.5 * u.AU)) is True
+
+
+def test_can_handle_with_distance_and_time():
+    """Distance + Time together should be handleable."""
+    assert SOARClient._can_handle_query(
+        a.soar.Distance(0.3 * u.AU, 0.5 * u.AU),
+        a.Time("2023-01-01", "2023-01-02"),
+    ) is True
+
+
+def test_can_handle_wrong_provider():
+    """A non-SOAR provider should be rejected."""
+    assert SOARClient._can_handle_query(
+        a.Time("2023-01-01", "2023-01-02"),
+        a.Provider("SDAC"),
+    ) is False
+
+
+def test_can_handle_unknown_instrument():
+    """An instrument not in the SOAR registry should be rejected."""
+    assert SOARClient._can_handle_query(
+        a.Time("2023-01-01", "2023-01-02"),
+        a.Instrument("AIA"),
+    ) is False
+
+
+def test_can_handle_unsupported_attr():
+    """An attr type not in the required/optional sets should be rejected."""
+    assert SOARClient._can_handle_query(
+        a.Time("2023-01-01", "2023-01-02"),
+        a.Physobs("intensity"),
+    ) is False
+
+
+def test_can_handle_time_only():
+    """Time with no instrument should be handleable (the no-instrument search path)."""
+    assert SOARClient._can_handle_query(a.Time("2023-01-01", "2023-01-02")) is True

--- a/sunpy_soar/tests/test_sunpy_soar.py
+++ b/sunpy_soar/tests/test_sunpy_soar.py
@@ -329,6 +329,79 @@ def test_distance_join_query():
     )
 
 
+def test_construct_payload_insitu_no_join():
+    """In-situ instruments (e.g. MAG) should produce SELECT * with no JOIN."""
+    result = SOARClient._construct_payload(
+        [
+            "instrument='MAG'",
+            "begin_time>='2020-04-16 00:00:00' AND begin_time<='2020-04-17 00:00:00'",
+            "descriptor='mag-rtn-normal-1-minute'",
+        ]
+    )
+    assert result["REQUEST"] == "doQuery"
+    assert "SELECT *" in result["QUERY"]
+    assert "JOIN" not in result["QUERY"]
+    assert "FROM v_sc_data_item" in result["QUERY"]
+
+
+def test_construct_payload_descriptor_infers_instrument():
+    """When no instrument= is given, instrument should be inferred from the descriptor."""
+    result = SOARClient._construct_payload(
+        [
+            "begin_time>='2021-02-01 00:00:00' AND begin_time<='2021-02-02 00:00:00'",
+            "level='L1'",
+            "descriptor='eui-fsi174-image'",
+        ]
+    )
+    # EUI is inferred from 'eui-fsi174-image' and should trigger the join path
+    assert "JOIN v_eui_sc_fits" in result["QUERY"]
+    assert "h1.descriptor='eui-fsi174-image'" in result["QUERY"]
+
+
+def test_construct_payload_solohi_mapping():
+    """SOLOHI should be mapped to SHI for the instrument table."""
+    result = SOARClient._construct_payload(
+        [
+            "instrument='SOLOHI'",
+            "begin_time>='2021-02-01 00:00:00' AND begin_time<='2021-02-02 00:00:00'",
+            "level='L1'",
+        ]
+    )
+    assert "JOIN v_shi_sc_fits" in result["QUERY"]
+
+
+def test_construct_payload_stix_mapping():
+    """STIX should be mapped to STX but should not trigger a join (not a remote sensing join instrument)."""
+    result = SOARClient._construct_payload(
+        [
+            "instrument='STIX'",
+            "begin_time>='2021-02-01 00:00:00' AND begin_time<='2021-02-02 00:00:00'",
+            "level='L1'",
+        ]
+    )
+    # STIX (STX) is not in the remote sensing join list
+    assert "SELECT *" in result["QUERY"]
+    assert "JOIN" not in result["QUERY"]
+
+
+def test_construct_payload_distance_with_time():
+    """When both distance and time are present, the query method should be doQueryFilteredByDistance
+    and the DISTANCE parameter should be appended with '&' rather than ' AND '."""
+    result = SOARClient._construct_payload(
+        [
+            "instrument='RPW'",
+            "begin_time>='2023-04-27 00:00:00' AND begin_time<='2023-04-28 00:00:00'",
+            "level='L2'",
+            "DISTANCE(0.45,0.46)",
+        ]
+    )
+    assert result["REQUEST"] == "doQueryFilteredByDistance"
+    assert "begin_time>='2023-04-27 00:00:00'" in result["QUERY"]
+    assert "&DISTANCE(0.45,0.46)" in result["QUERY"]
+    # DISTANCE should not appear with ' AND ' prefix
+    assert " AND DISTANCE" not in result["QUERY"]
+
+
 @pytest.mark.remote_data
 def test_distance_search_remote_sensing():
     instrument = a.Instrument("RPW")

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ min_version = 4.0
 requires =
     tox-pypi-filter>=0.14
 envlist =
-    py{312,313,314}
+    py{312,313,314}{,-online}
     py314-devdeps
     py312-oldestdeps
     codestyle
@@ -18,6 +18,7 @@ description =
     run tests
     oldestdeps: with the oldest supported version of key dependencies
     devdeps: with the latest developer version of key dependencies
+    online: that require remote data (as well as the offline ones)
 pass_env =
     # A variable to tell tests we are on a CI system
     CI
@@ -57,6 +58,7 @@ commands =
     --cov-report=xml \
     --cov=sunpy_soar \
     --cov-config={toxinidir}/.coveragerc \
+    online: --remote-data=any \
     {toxinidir}/docs \
     {posargs}
 


### PR DESCRIPTION
This is one of the things for #196 

The first commit creates an offline build, the second fixes the existing tests, and then the latter tests are me letting an LLM generate some offline only tests.

This gets us up to 87% coverage offline on client.py and 100% on all other (non-test) files.

## AI Assistance Disclosure

<!--
To support transparency and sustainable collaboration, please indicate whether AI-assisted tools were used in preparing this pull request. 
For further details see our documentation on the fair and appropriate [usage of AI](https://docs.sunpy.org/en/latest/dev_guide/contents/ai_usage.html).
-->

AI tools were used for:
- [ ] Code generation (e.g., when writing an implementation or fixing a bug)
- [x] Test/benchmark generation
- [ ] Documentation (including examples)
- [ ] Research and understanding
- [ ] No AI tools were used

> Regardless of AI use, the human contributor remains fully responsible for correctness, design choices, licensing compatibility, and long-term maintainability.